### PR TITLE
Ux UI window flow

### DIFF
--- a/plugins/SkyCultureMaker/src/CMakeLists.txt
+++ b/plugins/SkyCultureMaker/src/CMakeLists.txt
@@ -39,6 +39,7 @@ SET( SkyCultureMaker_SRCS
 
      types/CoordinateLine.hpp
      types/Drawing.hpp
+     types/DialogID.hpp
      types/DrawTools.hpp
      types/Lines.hpp
      types/StarLine.hpp

--- a/plugins/SkyCultureMaker/src/CMakeLists.txt
+++ b/plugins/SkyCultureMaker/src/CMakeLists.txt
@@ -34,6 +34,8 @@ SET( SkyCultureMaker_SRCS
      gui/ScmImageAnchored.cpp
      gui/ScmSkyCultureExportDialog.hpp
      gui/ScmSkyCultureExportDialog.cpp
+     gui/ScmHideOrAbortMakerDialog.hpp
+     gui/ScmHideOrAbortMakerDialog.cpp
 
      types/CoordinateLine.hpp
      types/Drawing.hpp
@@ -47,6 +49,7 @@ SET( SCM_UIS
      gui/scmConstellationDialog.ui
      gui/scmSkyCultureDialog.ui
      gui/scmSkyCultureExportDialog.ui
+     gui/scmHideOrAbortMakerDialog.ui
      gui/scmStartDialog.ui
 )     
 

--- a/plugins/SkyCultureMaker/src/ScmSkyCulture.cpp
+++ b/plugins/SkyCultureMaker/src/ScmSkyCulture.cpp
@@ -59,11 +59,12 @@ std::vector<scm::ScmConstellation> *scm::ScmSkyCulture::getConstellations()
 QJsonObject scm::ScmSkyCulture::toJson() const
 {
 	QJsonObject scJsonObj;
-	scJsonObj["id"] = id;
+	scJsonObj["id"]     = id;
 	scJsonObj["region"] = description.geoRegion;
 	// for some reason, the classification is inside an array, eg. ["historical"]
-	QJsonArray classificationArray = QJsonArray::fromStringList(QStringList() << classificationTypeToString(description.classification));
-	scJsonObj["classification"] = classificationArray;
+	QJsonArray classificationArray = QJsonArray::fromStringList(
+		QStringList() << classificationTypeToString(description.classification));
+	scJsonObj["classification"]                  = classificationArray;
 	scJsonObj["fallback_to_international_names"] = fallbackToInternationalNames;
 	QJsonArray constellationsArray;
 	for (const auto &constellation : constellations)
@@ -96,12 +97,12 @@ bool scm::ScmSkyCulture::saveDescriptionAsMarkdown(QFile file)
 	if (file.open(QIODevice::WriteOnly | QIODevice::Text))
 	{
 		const scm::Description &desc = ScmSkyCulture::description;
-		const scm::License license = scm::LICENSES.at(desc.license);
+		const scm::License license   = scm::LICENSES.at(desc.license);
 
 		QTextStream out(&file);
 		out << "# " << desc.name << "\n\n";
 		out << "## Authors\n" << desc.authors << "\n\n";
-		out << "## License\n### " << license.name << "\n"<< license.description << "\n\n";
+		out << "## License\n### " << license.name << "\n" << license.description << "\n\n";
 		out << "## Culture Description\n" << desc.cultureDescription << "\n\n";
 		out << "## About\n" << desc.about << "\n\n";
 

--- a/plugins/SkyCultureMaker/src/SkyCultureMaker.cpp
+++ b/plugins/SkyCultureMaker/src/SkyCultureMaker.cpp
@@ -12,6 +12,7 @@
 #include "gui/ScmSkyCultureDialog.hpp"
 #include "gui/ScmSkyCultureExportDialog.hpp"
 #include "gui/ScmStartDialog.hpp"
+#include "gui/ScmHideOrAbortMakerDialog.hpp"
 
 #include "ScmDraw.hpp"
 #include <vector>
@@ -80,6 +81,7 @@ SkyCultureMaker::SkyCultureMaker()
 	scmSkyCultureDialog    	  = new ScmSkyCultureDialog(this);
 	scmConstellationDialog 	  = new ScmConstellationDialog(this);
 	scmSkyCultureExportDialog = new ScmSkyCultureExportDialog(this);
+	scmHideOrAbortMakerDialog = new ScmHideOrAbortMakerDialog(this);
 }
 
 /*************************************************************************
@@ -93,6 +95,7 @@ SkyCultureMaker::~SkyCultureMaker()
 	delete scmSkyCultureDialog;
 	delete scmConstellationDialog;
 	delete scmSkyCultureExportDialog;
+	delete scmHideOrAbortMakerDialog;
 
 	if (currentSkyCulture != nullptr)
 	{
@@ -281,6 +284,14 @@ void SkyCultureMaker::setSkyCultureExportDialogVisibility(bool b)
 	if (b != scmSkyCultureExportDialog->visible())
 	{
 		scmSkyCultureExportDialog->setVisible(b);
+	}
+}
+
+void SkyCultureMaker::setHideOrAbortMakerVisibility(bool b)
+{
+	if (b != scmHideOrAbortMakerDialog->visible())
+	{
+		scmHideOrAbortMakerDialog->setVisible(b);
 	}
 }
 

--- a/plugins/SkyCultureMaker/src/SkyCultureMaker.cpp
+++ b/plugins/SkyCultureMaker/src/SkyCultureMaker.cpp
@@ -9,10 +9,10 @@
 #include "StelPainter.hpp"
 #include "StelProjector.hpp"
 #include "gui/ScmConstellationDialog.hpp"
+#include "gui/ScmHideOrAbortMakerDialog.hpp"
 #include "gui/ScmSkyCultureDialog.hpp"
 #include "gui/ScmSkyCultureExportDialog.hpp"
 #include "gui/ScmStartDialog.hpp"
-#include "gui/ScmHideOrAbortMakerDialog.hpp"
 
 #include "ScmDraw.hpp"
 #include <vector>
@@ -76,10 +76,10 @@ SkyCultureMaker::SkyCultureMaker()
 	setObjectName("SkyCultureMaker");
 	font.setPixelSize(25);
 
-	drawObj                	  = new scm::ScmDraw();
-	scmStartDialog         	  = new ScmStartDialog(this);
-	scmSkyCultureDialog    	  = new ScmSkyCultureDialog(this);
-	scmConstellationDialog 	  = new ScmConstellationDialog(this);
+	drawObj                   = new scm::ScmDraw();
+	scmStartDialog            = new ScmStartDialog(this);
+	scmSkyCultureDialog       = new ScmSkyCultureDialog(this);
+	scmConstellationDialog    = new ScmConstellationDialog(this);
 	scmSkyCultureExportDialog = new ScmSkyCultureExportDialog(this);
 	scmHideOrAbortMakerDialog = new ScmHideOrAbortMakerDialog(this);
 }
@@ -189,6 +189,12 @@ void SkyCultureMaker::startScmProcess()
 
 void SkyCultureMaker::stopScmProcess()
 {
+	// If the hide or abort dialog is visible, we do not want to stop the process directly
+	if (scmHideOrAbortMakerDialog->visible())
+	{
+		return;
+	}
+
 	if (false != isScmEnabled)
 	{
 		isScmEnabled = false;
@@ -199,6 +205,7 @@ void SkyCultureMaker::stopScmProcess()
 	{
 		scmStartDialog->setVisible(false);
 	}
+	// Any dialogs are open -> hide or abort window
 	else
 	{
 		setHideOrAbortMakerDialogVisibility(true);
@@ -388,13 +395,12 @@ bool SkyCultureMaker::saveSkyCultureDescription()
 	return false;
 }
 
-void SkyCultureMaker::hideAllDialogsAndDisableSCM()
+void SkyCultureMaker::hideAllDialogs()
 {
 	setHideOrAbortMakerDialogVisibility(false);
 	setSkyCultureDialogVisibility(false);
 	setConstellationDialogVisibility(false);
 	setSkyCultureExportDialogVisibility(false);
-	setIsScmEnabled(false); // Disable the Sky Culture Maker
 }
 
 void SkyCultureMaker::saveScmDialogVisibilityState()
@@ -448,7 +454,6 @@ void SkyCultureMaker::resetScmDialogsVisibilityState()
 		scmDialogVisibilityMap[key] = false;
 	}
 }
-
 
 void SkyCultureMaker::resetScmDialogs()
 {

--- a/plugins/SkyCultureMaker/src/SkyCultureMaker.cpp
+++ b/plugins/SkyCultureMaker/src/SkyCultureMaker.cpp
@@ -390,6 +390,7 @@ bool SkyCultureMaker::saveSkyCultureDescription()
 
 void SkyCultureMaker::hideAllDialogsAndDisableSCM()
 {
+	setHideOrAbortMakerDialogVisibility(false);
 	setSkyCultureDialogVisibility(false);
 	setConstellationDialogVisibility(false);
 	setSkyCultureExportDialogVisibility(false);
@@ -400,15 +401,15 @@ void SkyCultureMaker::saveScmDialogVisibilityState()
 {
 	if (scmSkyCultureDialog != nullptr)
 	{
-		scmDialogVisibilityMap[DialogID::SkyCultureDialog] = scmSkyCultureDialog->visible();
+		scmDialogVisibilityMap[scm::DialogID::SkyCultureDialog] = scmSkyCultureDialog->visible();
 	}
 	if (scmConstellationDialog != nullptr)
 	{
-		scmDialogVisibilityMap[DialogID::ConstellationDialog] = scmConstellationDialog->visible();
+		scmDialogVisibilityMap[scm::DialogID::ConstellationDialog] = scmConstellationDialog->visible();
 	}
 	if (scmSkyCultureExportDialog != nullptr)
 	{
-		scmDialogVisibilityMap[DialogID::SkyCultureExportDialog] = scmSkyCultureExportDialog->visible();
+		scmDialogVisibilityMap[scm::DialogID::SkyCultureExportDialog] = scmSkyCultureExportDialog->visible();
 	}
 }
 
@@ -416,15 +417,15 @@ void SkyCultureMaker::restoreScmDialogVisibilityState()
 {
 	if (scmSkyCultureDialog != nullptr)
 	{
-		setSkyCultureDialogVisibility(scmDialogVisibilityMap[DialogID::SkyCultureDialog]);
+		setSkyCultureDialogVisibility(scmDialogVisibilityMap[scm::DialogID::SkyCultureDialog]);
 	}
 	if (scmConstellationDialog != nullptr)
 	{
-		setConstellationDialogVisibility(scmDialogVisibilityMap[DialogID::ConstellationDialog]);
+		setConstellationDialogVisibility(scmDialogVisibilityMap[scm::DialogID::ConstellationDialog]);
 	}
 	if (scmSkyCultureExportDialog != nullptr)
 	{
-		setSkyCultureExportDialogVisibility(scmDialogVisibilityMap[DialogID::SkyCultureExportDialog]);
+		setSkyCultureExportDialogVisibility(scmDialogVisibilityMap[scm::DialogID::SkyCultureExportDialog]);
 	}
 }
 

--- a/plugins/SkyCultureMaker/src/SkyCultureMaker.cpp
+++ b/plugins/SkyCultureMaker/src/SkyCultureMaker.cpp
@@ -177,7 +177,14 @@ void SkyCultureMaker::startScmProcess()
 		emit eventIsScmEnabled(true);
 	}
 
-	scmStartDialog->setVisible(true);
+	if (isAnyDialogHidden())
+	{
+		restoreScmDialogVisibilityState();
+	}
+	else
+	{
+		scmStartDialog->setVisible(true);
+	}
 }
 
 void SkyCultureMaker::stopScmProcess()
@@ -188,14 +195,14 @@ void SkyCultureMaker::stopScmProcess()
 		emit eventIsScmEnabled(false);
 	}
 
-	// TODO: close or delete all dialogs related to the creation process
 	if (scmStartDialog->visible())
 	{
 		scmStartDialog->setVisible(false);
 	}
-
-	setSkyCultureDialogVisibility(false);
-	setConstellationDialogVisibility(false);
+	else
+	{
+		setHideOrAbortMakerDialogVisibility(true);
+	}
 }
 
 void SkyCultureMaker::draw(StelCore *core)
@@ -287,7 +294,7 @@ void SkyCultureMaker::setSkyCultureExportDialogVisibility(bool b)
 	}
 }
 
-void SkyCultureMaker::setHideOrAbortMakerVisibility(bool b)
+void SkyCultureMaker::setHideOrAbortMakerDialogVisibility(bool b)
 {
 	if (b != scmHideOrAbortMakerDialog->visible())
 	{
@@ -379,4 +386,72 @@ bool SkyCultureMaker::saveSkyCultureDescription()
 	}
 
 	return false;
+}
+
+void SkyCultureMaker::hideAllDialogsAndDisableSCM()
+{
+	setSkyCultureDialogVisibility(false);
+	setConstellationDialogVisibility(false);
+	setSkyCultureExportDialogVisibility(false);
+	setIsScmEnabled(false); // Disable the Sky Culture Maker
+}
+
+void SkyCultureMaker::saveScmDialogVisibilityState()
+{
+	if (scmSkyCultureDialog != nullptr)
+	{
+		scmDialogVisibilityMap[DialogID::SkyCultureDialog] = scmSkyCultureDialog->visible();
+	}
+	if (scmConstellationDialog != nullptr)
+	{
+		scmDialogVisibilityMap[DialogID::ConstellationDialog] = scmConstellationDialog->visible();
+	}
+	if (scmSkyCultureExportDialog != nullptr)
+	{
+		scmDialogVisibilityMap[DialogID::SkyCultureExportDialog] = scmSkyCultureExportDialog->visible();
+	}
+}
+
+void SkyCultureMaker::restoreScmDialogVisibilityState()
+{
+	if (scmSkyCultureDialog != nullptr)
+	{
+		setSkyCultureDialogVisibility(scmDialogVisibilityMap[DialogID::SkyCultureDialog]);
+	}
+	if (scmConstellationDialog != nullptr)
+	{
+		setConstellationDialogVisibility(scmDialogVisibilityMap[DialogID::ConstellationDialog]);
+	}
+	if (scmSkyCultureExportDialog != nullptr)
+	{
+		setSkyCultureExportDialogVisibility(scmDialogVisibilityMap[DialogID::SkyCultureExportDialog]);
+	}
+}
+
+bool SkyCultureMaker::isAnyDialogHidden() const
+{
+	for (bool visible : scmDialogVisibilityMap.values())
+	{
+		if (visible)
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+void SkyCultureMaker::resetScmDialogsVisibilityState()
+{
+	for (auto key : scmDialogVisibilityMap.keys())
+	{
+		scmDialogVisibilityMap[key] = false;
+	}
+}
+
+
+void SkyCultureMaker::resetScmDialogs()
+{
+	resetScmDialogsVisibilityState(); // Reset the visibility state of all dialogs
+	scmSkyCultureDialog->resetDialog();
+	scmConstellationDialog->resetDialog();
 }

--- a/plugins/SkyCultureMaker/src/SkyCultureMaker.hpp
+++ b/plugins/SkyCultureMaker/src/SkyCultureMaker.hpp
@@ -9,6 +9,7 @@
 #include "StelObjectModule.hpp"
 #include "StelTranslator.hpp"
 #include "VecMath.hpp"
+#include "types/DialogID.hpp"
 #include <QFile>
 
 #include <QFont>
@@ -29,16 +30,6 @@ class SkyCultureMaker : public StelModule
 public:
 	SkyCultureMaker();
 	~SkyCultureMaker() override;
-
-	enum class DialogID
-	{
-		None,
-		StartDialog,
-		SkyCultureDialog,
-		SkyCultureExportDialog,
-		HideOrAbortMakerDialog,
-		ConstellationDialog
-	};
 
 	/// @brief Set the toggle value for a given action.
 	/// @param toggle The toggled value to be set.
@@ -248,12 +239,12 @@ private:
 	 * Store the visibility state of the SCM dialogs
 	 * The key is the dialog ID, the value is true if the dialog was hidden, false if newly created.
 	 */
-	QMap<DialogID, bool> scmDialogVisibilityMap = {
-		{DialogID::StartDialog, false},
-		{DialogID::SkyCultureDialog, false},
-		{DialogID::ConstellationDialog, false},
-		{DialogID::SkyCultureExportDialog, false},
-		{DialogID::HideOrAbortMakerDialog, false}
+	QMap<scm::DialogID, bool> scmDialogVisibilityMap = {
+		{scm::DialogID::StartDialog, false},
+		{scm::DialogID::SkyCultureDialog, false},
+		{scm::DialogID::ConstellationDialog, false},
+		{scm::DialogID::SkyCultureExportDialog, false},
+		{scm::DialogID::HideOrAbortMakerDialog, false}
 	};
 };
 

--- a/plugins/SkyCultureMaker/src/SkyCultureMaker.hpp
+++ b/plugins/SkyCultureMaker/src/SkyCultureMaker.hpp
@@ -76,6 +76,13 @@ public:
 	void setSkyCultureExportDialogVisibility(bool b);
 
 	/**
+	 * @brief Shows the hide or abort maker dialog.
+	 *
+	 * @param b The boolean value to be set.
+	 */
+	void setHideOrAbortMakerVisibility(bool b);
+
+	/**
 	 * @brief Toggles the usage of the line draw.
 	 *
 	 * @param b The boolean value to be set.
@@ -187,6 +194,9 @@ private:
 
 	/// Dialog for exporting a sky culture
 	ScmSkyCultureExportDialog *scmSkyCultureExportDialog = nullptr;
+
+	/// Dialog for hiding or aborting maker process
+	ScmHideOrAbortMakerDialog *scmHideOrAbortMakerDialog = nullptr;
 
 	/// The current sky culture
 	scm::ScmSkyCulture *currentSkyCulture = nullptr;

--- a/plugins/SkyCultureMaker/src/SkyCultureMaker.hpp
+++ b/plugins/SkyCultureMaker/src/SkyCultureMaker.hpp
@@ -26,6 +26,7 @@ class ScmHideOrAbortMakerDialog;
 class SkyCultureMaker : public StelModule
 {
 	Q_OBJECT
+	// TODO: var - getter - setter - trigger
 	Q_PROPERTY(bool enabledScm READ getIsScmEnabled WRITE setIsScmEnabled NOTIFY eventIsScmEnabled)
 public:
 	SkyCultureMaker();
@@ -89,7 +90,7 @@ public:
 	 * 
 	 * @param b The boolean value to be set.
 	 */
-	void hideAllDialogsAndDisableSCM();
+	void hideAllDialogs();
 
 	/**
 	 * @brief Toggles the usage of the line draw.
@@ -240,12 +241,12 @@ private:
 	 * The key is the dialog ID, the value is true if the dialog was hidden, false if newly created.
 	 */
 	QMap<scm::DialogID, bool> scmDialogVisibilityMap = {
-		{scm::DialogID::StartDialog, false},
-		{scm::DialogID::SkyCultureDialog, false},
-		{scm::DialogID::ConstellationDialog, false},
+		{scm::DialogID::StartDialog,            false},
+		{scm::DialogID::SkyCultureDialog,       false},
+		{scm::DialogID::ConstellationDialog,    false},
 		{scm::DialogID::SkyCultureExportDialog, false},
 		{scm::DialogID::HideOrAbortMakerDialog, false}
-	};
+        };
 };
 
 #include "StelPluginInterface.hpp"

--- a/plugins/SkyCultureMaker/src/SkyCultureMaker.hpp
+++ b/plugins/SkyCultureMaker/src/SkyCultureMaker.hpp
@@ -19,6 +19,7 @@ class ScmSkyCultureDialog;
 class ScmConstellationDialog;
 class ScmStartDialog;
 class ScmSkyCultureExportDialog;
+class ScmHideOrAbortMakerDialog;
 
 /// This is an example of a plug-in which can be dynamically loaded into stellarium
 class SkyCultureMaker : public StelModule
@@ -28,6 +29,16 @@ class SkyCultureMaker : public StelModule
 public:
 	SkyCultureMaker();
 	~SkyCultureMaker() override;
+
+	enum class DialogID
+	{
+		None,
+		StartDialog,
+		SkyCultureDialog,
+		SkyCultureExportDialog,
+		HideOrAbortMakerDialog,
+		ConstellationDialog
+	};
 
 	/// @brief Set the toggle value for a given action.
 	/// @param toggle The toggled value to be set.
@@ -80,7 +91,14 @@ public:
 	 *
 	 * @param b The boolean value to be set.
 	 */
-	void setHideOrAbortMakerVisibility(bool b);
+	void setHideOrAbortMakerDialogVisibility(bool b);
+
+	/**
+	 * @brief Set the visibility of all dialogs.
+	 * 
+	 * @param b The boolean value to be set.
+	 */
+	void hideAllDialogsAndDisableSCM();
 
 	/**
 	 * @brief Toggles the usage of the line draw.
@@ -150,6 +168,31 @@ public:
 	 */
 	QFile getScmDescriptionFile();
 
+	/**
+	 * @brief Saves the visibility state of the SCM dialogs.
+	 */
+	void saveScmDialogVisibilityState();
+
+	/**
+	 * @brief Restores the visibility state of the SCM dialogs.
+	 */
+	void restoreScmDialogVisibilityState();
+
+	/**
+	 * @brief Checks if any SCM dialog is currently hidden.
+	 */
+	bool isAnyDialogHidden() const;
+
+	/**
+	 * @brief Resets all SCM dialogs content and visibility states.
+	*/
+	void resetScmDialogs();
+
+	/**
+	 * @brief Resets the visibility state of the SCM dialogs.
+	 */
+	void resetScmDialogsVisibilityState();
+
 signals:
 	void eventIsScmEnabled(bool b);
 
@@ -200,6 +243,18 @@ private:
 
 	/// The current sky culture
 	scm::ScmSkyCulture *currentSkyCulture = nullptr;
+
+	/**
+	 * Store the visibility state of the SCM dialogs
+	 * The key is the dialog ID, the value is true if the dialog was hidden, false if newly created.
+	 */
+	QMap<DialogID, bool> scmDialogVisibilityMap = {
+		{DialogID::StartDialog, false},
+		{DialogID::SkyCultureDialog, false},
+		{DialogID::ConstellationDialog, false},
+		{DialogID::SkyCultureExportDialog, false},
+		{DialogID::HideOrAbortMakerDialog, false}
+	};
 };
 
 #include "StelPluginInterface.hpp"

--- a/plugins/SkyCultureMaker/src/gui/ScmConstellationDialog.cpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmConstellationDialog.cpp
@@ -42,6 +42,7 @@ void ScmConstellationDialog::close()
 
 void ScmConstellationDialog::createDialogContent()
 {
+	isDialogInitialized = true;
 	ui->setupUi(dialog);
 	imageItem->hide();
 	ui->artwork_image->setScene(imageItem->scene());
@@ -290,6 +291,12 @@ void ScmConstellationDialog::saveConstellation()
 
 void ScmConstellationDialog::resetDialog()
 {
+	// If the dialog was not initialized, the ui elements do not exist yet.
+	if (!isDialogInitialized)
+	{
+		return;
+	}
+
 	activeTool = scm::DrawTools::None;
 	ui->penBtn->setChecked(false);
 	ui->eraserBtn->setChecked(false);

--- a/plugins/SkyCultureMaker/src/gui/ScmConstellationDialog.hpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmConstellationDialog.hpp
@@ -44,7 +44,7 @@ private:
 	Ui_scmConstellationDialog *ui = nullptr;
 	SkyCultureMaker *maker        = nullptr;
 	scm::DrawTools activeTool     = scm::DrawTools::None;
-	bool isDialogInitialized = false;
+	bool isDialogInitialized      = false;
 
 	/// Identifier of the constellation
 	QString constellationId;

--- a/plugins/SkyCultureMaker/src/gui/ScmConstellationDialog.hpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmConstellationDialog.hpp
@@ -23,6 +23,11 @@ public:
 	ScmConstellationDialog(SkyCultureMaker *maker);
 	~ScmConstellationDialog() override;
 
+	/**
+	 * @brief Resets the constellation dialog data.
+	 */
+	void resetDialog();
+
 public slots:
 	void retranslate() override;
 	void close() override;
@@ -39,6 +44,7 @@ private:
 	Ui_scmConstellationDialog *ui = nullptr;
 	SkyCultureMaker *maker        = nullptr;
 	scm::DrawTools activeTool     = scm::DrawTools::None;
+	bool isDialogInitialized = false;
 
 	/// Identifier of the constellation
 	QString constellationId;
@@ -78,11 +84,6 @@ private:
 	 * @brief Resets and closes the dialog.
 	 */
 	void cancel();
-
-	/**
-	 * @brief Resets the constellation dialog data.
-	 */
-	void resetDialog();
 };
 
 #endif // SCM_CONSTELLATION_DIALOG_HPP

--- a/plugins/SkyCultureMaker/src/gui/ScmHideOrAbortMakerDialog.cpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmHideOrAbortMakerDialog.cpp
@@ -1,0 +1,60 @@
+#include "ScmHideOrAbortMakerDialog.hpp"
+#include "ui_scmHideOrAbortMakerDialog.h"
+#include <cassert>
+#include <QDebug>
+
+ScmStartDialog::ScmHideOrAbortMakerDialog(SkyCultureMaker *maker)
+	: StelDialog("ScmHideOrAbortMakerDialog")
+	, maker(maker)
+{
+	assert(maker != nullptr);
+	ui = new Ui_ScmHideOrAbortMakerDialog;
+}
+
+ScmHideOrAbortMakerDialog::~ScmHideOrAbortMakerDialog()
+{
+	if (ui != nullptr)
+	{
+		delete ui;
+	}
+
+	qDebug() << "Unloaded the ScmHideOrAbortMakerDialog";
+}
+
+void ScmHideOrAbortMakerDialog::retranslate()
+{
+	if (dialog)
+	{
+		ui->retranslateUi(dialog);
+	}
+}
+
+void ScmHideOrAbortMakerDialog::createDialogContent()
+{
+	ui->setupUi(dialog);
+
+	// connect(&StelApp::getInstance(), SIGNAL(languageChanged()), this, SLOT(retranslate()));
+	connect(ui->titleBar, &TitleBar::closeClicked, this, &ScmHideOrAbortMakerDialog::closeDialog);
+	connect(ui->titleBar, SIGNAL(movedTo(QPoint)), this, SLOT(handleMovedTo(QPoint)));
+
+	// Buttons
+	connect(ui->scmMakerAbortButton, &QPushButton::clicked, this, &ScmHideOrAbortMakerDialog::closeDialog); // Abort
+	connect(ui->scmMakerHidehButton, &QPushButton::clicked, this, &ScmHideOrAbortMakerDialog::hideScmCreationProcess); // Hide
+	connect(ui->scmMakerCancelButton, &QPushButton::clicked, this, &ScmHideOrAbortMakerDialog::closeDialog); // Abort
+}
+
+// TODO
+void ScmHideOrAbortMakerDialog::hideScmCreationProcess()
+{
+	// dialog->setVisible(false);                  // Close the dialog before starting the editor
+	// maker->setSkyCultureDialogVisibility(true); // Start the editor dialog for creating a new Sky Culture
+	// maker->setNewSkyCulture();
+}
+
+// TODO
+void ScmHideOrAbortMakerDialog::abortScmCreationProcess() {}
+
+// TODO
+void ScmHideOrAbortMakerDialog::closeDialog()
+{
+}

--- a/plugins/SkyCultureMaker/src/gui/ScmHideOrAbortMakerDialog.cpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmHideOrAbortMakerDialog.cpp
@@ -38,23 +38,26 @@ void ScmHideOrAbortMakerDialog::createDialogContent()
 	connect(ui->titleBar, SIGNAL(movedTo(QPoint)), this, SLOT(handleMovedTo(QPoint)));
 
 	// Buttons
-	connect(ui->scmMakerAbortButton, &QPushButton::clicked, this, &ScmHideOrAbortMakerDialog::abortScmCreationProcess); // Abort
-	connect(ui->scmMakerHidehButton, &QPushButton::clicked, this, &ScmHideOrAbortMakerDialog::hideScmCreationProcess); // Hide
-	connect(ui->scmMakerCancelButton, &QPushButton::clicked, this, &ScmHideOrAbortMakerDialog::cancelDialog); // Cancel
+	connect(ui->scmMakerAbortButton, &QPushButton::clicked, this,
+	        &ScmHideOrAbortMakerDialog::abortScmCreationProcess); // Abort
+	connect(ui->scmMakerHidehButton, &QPushButton::clicked, this,
+	        &ScmHideOrAbortMakerDialog::hideScmCreationProcess); // Hide
+	connect(ui->scmMakerCancelButton, &QPushButton::clicked, this,
+	        &ScmHideOrAbortMakerDialog::cancelDialog); // Cancel
 }
 
 // TODO: save state of the current sky culture
 void ScmHideOrAbortMakerDialog::hideScmCreationProcess()
 {
 	maker->saveScmDialogVisibilityState();
-	maker->hideAllDialogsAndDisableSCM();
+	maker->hideAllDialogs();
 }
 
 // TODO: clear the current sky culture
 void ScmHideOrAbortMakerDialog::abortScmCreationProcess()
 {
 	maker->resetScmDialogs();
-	maker->hideAllDialogsAndDisableSCM();
+	maker->hideAllDialogs();
 }
 
 void ScmHideOrAbortMakerDialog::cancelDialog()

--- a/plugins/SkyCultureMaker/src/gui/ScmHideOrAbortMakerDialog.cpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmHideOrAbortMakerDialog.cpp
@@ -3,12 +3,12 @@
 #include <cassert>
 #include <QDebug>
 
-ScmStartDialog::ScmHideOrAbortMakerDialog(SkyCultureMaker *maker)
-	: StelDialog("ScmHideOrAbortMakerDialog")
+ScmHideOrAbortMakerDialog::ScmHideOrAbortMakerDialog(SkyCultureMaker *maker)
+	: StelDialogSeparate("ScmHideOrAbortMakerDialog")
 	, maker(maker)
 {
 	assert(maker != nullptr);
-	ui = new Ui_ScmHideOrAbortMakerDialog;
+	ui = new Ui_scmHideOrAbortMakerDialog;
 }
 
 ScmHideOrAbortMakerDialog::~ScmHideOrAbortMakerDialog()
@@ -34,27 +34,36 @@ void ScmHideOrAbortMakerDialog::createDialogContent()
 	ui->setupUi(dialog);
 
 	// connect(&StelApp::getInstance(), SIGNAL(languageChanged()), this, SLOT(retranslate()));
-	connect(ui->titleBar, &TitleBar::closeClicked, this, &ScmHideOrAbortMakerDialog::closeDialog);
+	connect(ui->titleBar, &TitleBar::closeClicked, this, &ScmHideOrAbortMakerDialog::cancelDialog);
 	connect(ui->titleBar, SIGNAL(movedTo(QPoint)), this, SLOT(handleMovedTo(QPoint)));
 
 	// Buttons
-	connect(ui->scmMakerAbortButton, &QPushButton::clicked, this, &ScmHideOrAbortMakerDialog::closeDialog); // Abort
+	connect(ui->scmMakerAbortButton, &QPushButton::clicked, this, &ScmHideOrAbortMakerDialog::abortScmCreationProcess); // Abort
 	connect(ui->scmMakerHidehButton, &QPushButton::clicked, this, &ScmHideOrAbortMakerDialog::hideScmCreationProcess); // Hide
-	connect(ui->scmMakerCancelButton, &QPushButton::clicked, this, &ScmHideOrAbortMakerDialog::closeDialog); // Abort
+	connect(ui->scmMakerCancelButton, &QPushButton::clicked, this, &ScmHideOrAbortMakerDialog::cancelDialog); // Cancel
 }
 
-// TODO
+// TODO: save state of the current sky culture
 void ScmHideOrAbortMakerDialog::hideScmCreationProcess()
 {
-	// dialog->setVisible(false);                  // Close the dialog before starting the editor
-	// maker->setSkyCultureDialogVisibility(true); // Start the editor dialog for creating a new Sky Culture
-	// maker->setNewSkyCulture();
+	maker->saveScmDialogVisibilityState();
+	maker->hideAllDialogsAndDisableSCM();
+	maker->setHideOrAbortMakerDialogVisibility(false);
 }
 
-// TODO
-void ScmHideOrAbortMakerDialog::abortScmCreationProcess() {}
-
-// TODO
-void ScmHideOrAbortMakerDialog::closeDialog()
+// TODO: clear the current sky culture
+void ScmHideOrAbortMakerDialog::abortScmCreationProcess()
 {
+	qDebug() << "Unloaded the ScmHideOrAbortMakerDialog 1";
+	maker->resetScmDialogs();
+	qDebug() << "Unloaded the ScmHideOrAbortMakerDialog 2";
+	maker->hideAllDialogsAndDisableSCM();
+	qDebug() << "Unloaded the ScmHideOrAbortMakerDialog 3";
+	maker->setHideOrAbortMakerDialogVisibility(false);
+	qDebug() << "Unloaded the ScmHideOrAbortMakerDialog 4";
+}
+
+void ScmHideOrAbortMakerDialog::cancelDialog()
+{
+	maker->setHideOrAbortMakerDialogVisibility(false);
 }

--- a/plugins/SkyCultureMaker/src/gui/ScmHideOrAbortMakerDialog.cpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmHideOrAbortMakerDialog.cpp
@@ -48,19 +48,13 @@ void ScmHideOrAbortMakerDialog::hideScmCreationProcess()
 {
 	maker->saveScmDialogVisibilityState();
 	maker->hideAllDialogsAndDisableSCM();
-	maker->setHideOrAbortMakerDialogVisibility(false);
 }
 
 // TODO: clear the current sky culture
 void ScmHideOrAbortMakerDialog::abortScmCreationProcess()
 {
-	qDebug() << "Unloaded the ScmHideOrAbortMakerDialog 1";
 	maker->resetScmDialogs();
-	qDebug() << "Unloaded the ScmHideOrAbortMakerDialog 2";
 	maker->hideAllDialogsAndDisableSCM();
-	qDebug() << "Unloaded the ScmHideOrAbortMakerDialog 3";
-	maker->setHideOrAbortMakerDialogVisibility(false);
-	qDebug() << "Unloaded the ScmHideOrAbortMakerDialog 4";
 }
 
 void ScmHideOrAbortMakerDialog::cancelDialog()

--- a/plugins/SkyCultureMaker/src/gui/ScmHideOrAbortMakerDialog.hpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmHideOrAbortMakerDialog.hpp
@@ -2,12 +2,12 @@
 #define SCMHIDEORABORTMAKERDIALOG_HPP
 
 #include "SkyCultureMaker.hpp"
-#include "StelDialog.hpp"
+#include "StelDialogSeparate.hpp"
 #include <QObject>
 
-class UI_scmHideOrAbortMakerDialog;
+class Ui_scmHideOrAbortMakerDialog;
 
-class ScmHideOrAbortMakerDialog : public StelDialog
+class ScmHideOrAbortMakerDialog : public StelDialogSeparate
 {
 protected:
 	void createDialogContent() override;
@@ -22,10 +22,10 @@ public slots:
 private slots:
 	void hideScmCreationProcess();
 	void abortScmCreationProcess();
-	void closeDialog();
+	void cancelDialog();
 
 private:
-	UI_scmHideOrAbortMakerDialog *ui  = nullptr;
+	Ui_scmHideOrAbortMakerDialog *ui  = nullptr;
 	SkyCultureMaker *maker = nullptr;
 };
 

--- a/plugins/SkyCultureMaker/src/gui/ScmHideOrAbortMakerDialog.hpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmHideOrAbortMakerDialog.hpp
@@ -1,0 +1,32 @@
+#ifndef SCMHIDEORABORTMAKERDIALOG_HPP
+#define SCMHIDEORABORTMAKERDIALOG_HPP
+
+#include "SkyCultureMaker.hpp"
+#include "StelDialog.hpp"
+#include <QObject>
+
+class UI_scmHideOrAbortMakerDialog;
+
+class ScmHideOrAbortMakerDialog : public StelDialog
+{
+protected:
+	void createDialogContent() override;
+
+public:
+	ScmHideOrAbortMakerDialog(SkyCultureMaker *maker);
+	~ScmHideOrAbortMakerDialog() override;
+
+public slots:
+	void retranslate() override;
+
+private slots:
+	void hideScmCreationProcess();
+	void abortScmCreationProcess();
+	void closeDialog();
+
+private:
+	UI_scmHideOrAbortMakerDialog *ui  = nullptr;
+	SkyCultureMaker *maker = nullptr;
+};
+
+#endif // SCMHIDEORABORTMAKERDIALOG_HPP

--- a/plugins/SkyCultureMaker/src/gui/ScmHideOrAbortMakerDialog.hpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmHideOrAbortMakerDialog.hpp
@@ -25,8 +25,8 @@ private slots:
 	void cancelDialog();
 
 private:
-	Ui_scmHideOrAbortMakerDialog *ui  = nullptr;
-	SkyCultureMaker *maker = nullptr;
+	Ui_scmHideOrAbortMakerDialog *ui = nullptr;
+	SkyCultureMaker *maker           = nullptr;
 };
 
 #endif // SCMHIDEORABORTMAKERDIALOG_HPP

--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
@@ -215,18 +215,18 @@ scm::Description ScmSkyCultureDialog::getDescriptionFromTextEdit() const
 	desc.cultureDescription = ui->cultureDescriptionTE->toPlainText();
 	desc.about              = ui->aboutTE->toPlainText();
 
-	desc.geoRegion          = ui->geoRegionTE->toPlainText();
-	desc.sky                = ui->skyTE->toPlainText();
-	desc.moonAndSun         = ui->moonSunTE->toPlainText();
-	desc.planets            = ui->planetsTE->toPlainText();
-	desc.zodiac             = ui->zodiacTE->toPlainText();
-	desc.milkyWay           = ui->milkyWayTE->toPlainText();
-	desc.otherObjects       = ui->otherObjectsTE->toPlainText();
+	desc.geoRegion    = ui->geoRegionTE->toPlainText();
+	desc.sky          = ui->skyTE->toPlainText();
+	desc.moonAndSun   = ui->moonSunTE->toPlainText();
+	desc.planets      = ui->planetsTE->toPlainText();
+	desc.zodiac       = ui->zodiacTE->toPlainText();
+	desc.milkyWay     = ui->milkyWayTE->toPlainText();
+	desc.otherObjects = ui->otherObjectsTE->toPlainText();
 
-	desc.constellations     = ui->constellationsDescTE->toPlainText();
-	desc.references         = ui->referencesTE->toPlainText();
-	desc.acknowledgements   = ui->acknowledgementsTE->toPlainText();
-	desc.classification     = ui->classificationCB->currentData().value<scm::ClassificationType>();
+	desc.constellations   = ui->constellationsDescTE->toPlainText();
+	desc.references       = ui->referencesTE->toPlainText();
+	desc.acknowledgements = ui->acknowledgementsTE->toPlainText();
+	desc.classification   = ui->classificationCB->currentData().value<scm::ClassificationType>();
 
 	return desc;
 }

--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
@@ -43,6 +43,9 @@ void ScmSkyCultureDialog::retranslate()
 void ScmSkyCultureDialog::close()
 {
 	maker->setSkyCultureDialogVisibility(false);
+	maker->setConstellationDialogVisibility(false);
+	maker->setSkyCultureExportDialogVisibility(false);
+	maker->setIsScmEnabled(false); // Disable the Sky Culture Maker
 }
 
 void ScmSkyCultureDialog::createDialogContent()

--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
@@ -32,6 +32,15 @@ void ScmSkyCultureDialog::setConstellations(std::vector<scm::ScmConstellation> *
 	}
 }
 
+void ScmSkyCultureDialog::resetConstellations()
+{
+	if (ui && dialog)
+	{
+		ui->constellationsList->clear();
+		constellations = nullptr; // Reset the constellations pointer
+	}
+}
+
 void ScmSkyCultureDialog::retranslate()
 {
 	if (dialog)
@@ -42,10 +51,7 @@ void ScmSkyCultureDialog::retranslate()
 
 void ScmSkyCultureDialog::close()
 {
-	maker->setSkyCultureDialogVisibility(false);
-	maker->setConstellationDialogVisibility(false);
-	maker->setSkyCultureExportDialogVisibility(false);
-	maker->setIsScmEnabled(false); // Disable the Sky Culture Maker
+	maker->setHideOrAbortMakerDialogVisibility(true);
 }
 
 void ScmSkyCultureDialog::createDialogContent()
@@ -234,5 +240,35 @@ void ScmSkyCultureDialog::setInfoLabel(const QString &text)
 	else
 	{
 		qDebug() << "ScmSkyCultureDialog: UI or dialog is not initialized.";
+	}
+}
+
+void ScmSkyCultureDialog::resetDialog()
+{
+	if (ui && dialog)
+	{
+		ui->skyCultureNameTE->clear();
+		ui->authorsTE->clear();
+		ui->cultureDescriptionTE->clear();
+		ui->aboutTE->clear();
+		ui->geoRegionTE->clear();
+		ui->skyTE->clear();
+		ui->moonSunTE->clear();
+		ui->planetsTE->clear();
+		ui->zodiacTE->clear();
+		ui->milkyWayTE->clear();
+		ui->otherObjectsTE->clear();
+		ui->constellationsDescTE->clear();
+		ui->referencesTE->clear();
+		ui->acknowledgementsTE->clear();
+
+		ui->licenseCB->setCurrentIndex(0);
+		ui->classificationCB->setCurrentIndex(0);
+
+		name.clear();
+		setIdFromName(name);
+		resetConstellations();
+		maker->setSkyCultureDescription(getDescriptionFromTextEdit());
+		updateRemoveConstellationButton();
 	}
 }

--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.cpp
@@ -268,6 +268,7 @@ void ScmSkyCultureDialog::resetDialog()
 		name.clear();
 		setIdFromName(name);
 		resetConstellations();
+		maker->setSkyCultureDialogInfoLabel("");
 		maker->setSkyCultureDescription(getDescriptionFromTextEdit());
 		updateRemoveConstellationButton();
 	}

--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.hpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureDialog.hpp
@@ -32,11 +32,21 @@ public:
 	void setConstellations(std::vector<scm::ScmConstellation> *constellations);
 
 	/**
+	 * @brief Resets the constellations to an empty vector.
+	 */
+	void resetConstellations();
+
+	/**
 	 * @brief Sets the info label text.
 	 *
 	 * @param text The text to set in the info label.
 	 */
 	void setInfoLabel(const QString &text);
+
+	/**
+	 * @brief Resets all fields in the dialog to their default values.
+	 */
+	void resetDialog();
 
 public slots:
 	void retranslate() override;

--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureExportDialog.cpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureExportDialog.cpp
@@ -35,11 +35,12 @@ void ScmSkyCultureExportDialog::createDialogContent()
 	connect(&StelApp::getInstance(), SIGNAL(languageChanged()), this, SLOT(retranslate()));
 	connect(ui->titleBar, SIGNAL(movedTo(QPoint)), this, SLOT(handleMovedTo(QPoint)));
 	connect(ui->titleBar, &TitleBar::closeClicked, this, &ScmSkyCultureExportDialog::close);
-	connect(ui->exportBtn, &QPushButton::clicked, this, &ScmSkyCultureExportDialog::exportSkyCulture);
+	connect(ui->saveBtn, &QPushButton::clicked, this, &ScmSkyCultureExportDialog::saveSkyCulture);
+	connect(ui->saveAndExitBtn, &QPushButton::clicked, this, &ScmSkyCultureExportDialog::saveAndExitSkyCulture);
 	connect(ui->cancelBtn, &QPushButton::clicked, this, &ScmSkyCultureExportDialog::close);
 }
 
-void ScmSkyCultureExportDialog::exportSkyCulture()
+void ScmSkyCultureExportDialog::saveSkyCulture()
 {
 	if (maker == nullptr) {
 		qWarning() << "SkyCultureMaker: maker is nullptr. Cannot export sky culture.";
@@ -76,4 +77,11 @@ void ScmSkyCultureExportDialog::exportSkyCulture()
 	}
 
 	ScmSkyCultureExportDialog::close();
+}
+
+void ScmSkyCultureExportDialog::saveAndExitSkyCulture()
+{
+	saveSkyCulture();
+	maker->resetScmDialogs();
+	maker->hideAllDialogsAndDisableSCM();
 }

--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureExportDialog.cpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureExportDialog.cpp
@@ -1,10 +1,10 @@
 #include "ScmSkyCultureExportDialog.hpp"
-#include "ui_scmSkyCultureExportDialog.h"
 #include "ScmSkyCulture.hpp"
-#include <QJsonObject>
+#include "ui_scmSkyCultureExportDialog.h"
 #include <QJsonDocument>
+#include <QJsonObject>
 
-ScmSkyCultureExportDialog::ScmSkyCultureExportDialog(SkyCultureMaker *maker)
+ScmSkyCultureExportDialog::ScmSkyCultureExportDialog(SkyCultureMaker* maker)
 	: StelDialogSeparate("ScmSkyCultureExportDialog")
 	, maker(maker)
 {
@@ -42,14 +42,16 @@ void ScmSkyCultureExportDialog::createDialogContent()
 
 void ScmSkyCultureExportDialog::saveSkyCulture()
 {
-	if (maker == nullptr) {
+	if (maker == nullptr)
+	{
 		qWarning() << "SkyCultureMaker: maker is nullptr. Cannot export sky culture.";
 		ScmSkyCultureExportDialog::close();
 		return;
 	}
 
 	scm::ScmSkyCulture* currentSkyCulture = maker->getCurrentSkyCulture();
-	if (currentSkyCulture == nullptr) {
+	if (currentSkyCulture == nullptr)
+	{
 		qWarning() << "SkyCultureMaker: current sky culture is nullptr. Cannot export.";
 		maker->setSkyCultureDialogInfoLabel("ERROR: No sky culture is set.");
 		ScmSkyCultureExportDialog::close();
@@ -60,7 +62,7 @@ void ScmSkyCultureExportDialog::saveSkyCulture()
 	qDebug() << "Exporting sky culture...";
 	QJsonObject scJsonObject = currentSkyCulture->toJson();
 	QJsonDocument scJsonDoc(scJsonObject);
- 	qDebug().noquote() << scJsonDoc.toJson(QJsonDocument::Compact);
+	qDebug().noquote() << scJsonDoc.toJson(QJsonDocument::Compact);
 	// TODO: the error handling here should be improved once we also have to
 	// check whether the json file was successfully saved (#88)
 
@@ -83,5 +85,5 @@ void ScmSkyCultureExportDialog::saveAndExitSkyCulture()
 {
 	saveSkyCulture();
 	maker->resetScmDialogs();
-	maker->hideAllDialogsAndDisableSCM();
+	maker->hideAllDialogs();
 }

--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureExportDialog.hpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureExportDialog.hpp
@@ -22,7 +22,8 @@ private:
 	Ui_scmSkyCultureExportDialog *ui  = nullptr;
 	SkyCultureMaker *maker = nullptr;
 
-	void exportSkyCulture();
+	void saveSkyCulture();
+	void saveAndExitSkyCulture();
 };
 
 #endif // SCM_SKY_CULTURE_EXPORT_DIALOG_HPP

--- a/plugins/SkyCultureMaker/src/gui/ScmSkyCultureExportDialog.hpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmSkyCultureExportDialog.hpp
@@ -19,8 +19,8 @@ public slots:
 	void retranslate() override;
 
 private:
-	Ui_scmSkyCultureExportDialog *ui  = nullptr;
-	SkyCultureMaker *maker = nullptr;
+	Ui_scmSkyCultureExportDialog *ui = nullptr;
+	SkyCultureMaker *maker           = nullptr;
 
 	void saveSkyCulture();
 	void saveAndExitSkyCulture();

--- a/plugins/SkyCultureMaker/src/gui/ScmStartDialog.cpp
+++ b/plugins/SkyCultureMaker/src/gui/ScmStartDialog.cpp
@@ -61,6 +61,5 @@ void ScmStartDialog::startScmCreationProcess()
 
 void ScmStartDialog::closeDialog()
 {
-	StelDialog::close();
 	maker->setIsScmEnabled(false); // Disable the Sky Culture Maker
 }

--- a/plugins/SkyCultureMaker/src/gui/scmConstellationDialog.ui
+++ b/plugins/SkyCultureMaker/src/gui/scmConstellationDialog.ui
@@ -70,6 +70,19 @@
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_2">
          <item>
+          <widget class="QPushButton" name="penBtn">
+           <property name="text">
+            <string>Pen</string>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <property name="checked">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QPushButton" name="undoBtn">
            <property name="text">
             <string>Undo</string>
@@ -83,19 +96,6 @@
            </property>
            <property name="checkable">
             <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="penBtn">
-           <property name="text">
-            <string>Pen</string>
-           </property>
-           <property name="checkable">
-            <bool>true</bool>
-           </property>
-           <property name="checked">
-            <bool>false</bool>
            </property>
           </widget>
          </item>

--- a/plugins/SkyCultureMaker/src/gui/scmHideOrAbortMakerDialog.ui
+++ b/plugins/SkyCultureMaker/src/gui/scmHideOrAbortMakerDialog.ui
@@ -104,7 +104,7 @@
               </font>
              </property>
              <property name="text">
-              <string>Do you want to keep the chances (Hide) or abort the maker process (Abort)?</string>
+              <string>Hide maker in background or abort process?</string>
              </property>
              <property name="alignment">
               <set>Qt::AlignCenter</set>

--- a/plugins/SkyCultureMaker/src/gui/scmHideOrAbortMakerDialog.ui
+++ b/plugins/SkyCultureMaker/src/gui/scmHideOrAbortMakerDialog.ui
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>scmHideOrAbortMakerDialog</class>
+ <widget class="QWidget" name="scmHideOrAbortMakerDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>200</height>
+   </rect>
+  </property>
+  <property name="styleSheet">
+   <string notr="true"/>
+  </property>
+  <layout class="QVBoxLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="TitleBar" name="titleBar">
+     <property name="title" stdset="0">
+      <string>Sky Culture Maker</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="Content">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <item row="0" column="0" colspan="2">
+       <widget class="QFrame" name="frame">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::StyledPanel</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Raised</enum>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_3">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <item row="0" column="0">
+          <layout class="QVBoxLayout" name="verticalLayout">
+           <item>
+            <widget class="QLabel" name="label">
+             <property name="font">
+              <font>
+               <pointsize>16</pointsize>
+               <strikeout>false</strikeout>
+              </font>
+             </property>
+             <property name="text">
+              <string>Do you want to keep the chances (Hide) or abort the maker process (Abort)?</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout">
+             <item>
+              <widget class="QPushButton" name="scmMakerHidehButton">
+               <property name="text">
+                <string>Hide</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="scmMakerAbortButton">
+               <property name="text">
+                <string>Abort</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="scmMakerCancelButton">
+               <property name="text">
+                <string>Cancel</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>TitleBar</class>
+   <extends>QFrame</extends>
+   <header location="global">Dialog.hpp</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/plugins/SkyCultureMaker/src/gui/scmSkyCultureExportDialog.ui
+++ b/plugins/SkyCultureMaker/src/gui/scmSkyCultureExportDialog.ui
@@ -158,9 +158,16 @@
       <number>10</number>
      </property>
      <item>
-      <widget class="QPushButton" name="exportBtn">
+      <widget class="QPushButton" name="saveBtn">
        <property name="text">
-        <string>Export</string>
+        <string>Save</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="saveAndExitBtn">
+       <property name="text">
+        <string>Save and Exit</string>
        </property>
       </widget>
      </item>

--- a/plugins/SkyCultureMaker/src/types/DialogID.hpp
+++ b/plugins/SkyCultureMaker/src/types/DialogID.hpp
@@ -1,0 +1,17 @@
+#ifndef SCM_DIALOG_HPP
+#define SCM_DIALOG_HPP
+
+namespace scm
+{
+//! The possibles tools used for drawing.
+enum class DialogID
+{
+		StartDialog,
+		SkyCultureDialog,
+		SkyCultureExportDialog,
+		HideOrAbortMakerDialog,
+		ConstellationDialog
+};
+} // namespace scm
+
+#endif

--- a/plugins/SkyCultureMaker/src/types/DialogID.hpp
+++ b/plugins/SkyCultureMaker/src/types/DialogID.hpp
@@ -6,11 +6,11 @@ namespace scm
 //! The possibles tools used for drawing.
 enum class DialogID
 {
-		StartDialog,
-		SkyCultureDialog,
-		SkyCultureExportDialog,
-		HideOrAbortMakerDialog,
-		ConstellationDialog
+	StartDialog,
+	SkyCultureDialog,
+	SkyCultureExportDialog,
+	HideOrAbortMakerDialog,
+	ConstellationDialog
 };
 } // namespace scm
 

--- a/plugins/SkyCultureMaker/src/types/DrawTools.hpp
+++ b/plugins/SkyCultureMaker/src/types/DrawTools.hpp
@@ -1,5 +1,5 @@
 /**
- * @file StarLine.hpp
+ * @file DrawTools.hpp
  * @author vgerlach, lgrumbach
  * @brief Type describing the possible states of the draw tool.
  * @version 0.1


### PR DESCRIPTION
Added:
- #100
- #106
- #107
- #108

I found one bug in my testing, that I didn't fix yet. When toggling the scm with the button in the bottom bar, there can occur wrong behavior. For example, if you have the sky culture dialog open, click again on the button in the bottom bar and choose "cancel" in the pop up window (hide, abort, close), then the button is not glowing (deactivated).

Besides that, any other discovered bug by me was fixed. If you find more, please share in the issue.